### PR TITLE
docs: add Node.js requirement + Codespaces tip in Quickstart

### DIFF
--- a/docs/build/quickstart.mdx
+++ b/docs/build/quickstart.mdx
@@ -21,3 +21,15 @@ For those using AI assisted workflows (*i.e.*, Cursor + ChatGPT / Claude), we st
 ### Libraries
 
 <FeatureSection data={Libraries} />
+
+---
+
+## Notes for Developers
+
+Make sure you have **Node.js v18 or higher** installed before running the following commands:
+
+```bash
+yarn install
+yarn start
+```
+### 💡 Tip: If you are using GitHub Codespaces, the documentation will automatically open on port 3000 once the server starts.


### PR DESCRIPTION
This PR improves the Quickstart documentation by specifying the Node.js version requirement and adding a helpful tip for developers using GitHub Codespaces.
These additions make it easier for new developers to set up their environment and run the documentation locally.